### PR TITLE
[qpg6100] enable HW crypto support by default

### DIFF
--- a/src/qpg6100/crypto/qpg6100-mbedtls-config.h
+++ b/src/qpg6100/crypto/qpg6100-mbedtls-config.h
@@ -29,8 +29,7 @@
 #ifndef QGP6100_MBEDTLS_CONFIG_H
 #define QGP6100_MBEDTLS_CONFIG_H
 
-#ifdef QORVO_CRYPTO_ENGINE
-
+// Use Qorvo HW crypto support
 #undef MBEDTLS_ECP_WINDOW_SIZE
 #undef MBEDTLS_ECP_FIXED_POINT_OPTIM
 
@@ -39,13 +38,6 @@
 #define MBEDTLS_ECP_ALT
 #define MBEDTLS_ECJPAKE_ALT
 #define MBEDTLS_SHA256_ALT
-
-#else
-
-#define MBEDTLS_SLOW_CPU 1
-#define MBEDTLS_COMPUTATION_UNTILL_SEQ_NR 6
-
-#endif // QORVO_CRYPTO_ENGINE
 
 #include "mbedtls/check_config.h"
 

--- a/third_party/Qorvo/CMakeLists.txt
+++ b/third_party/Qorvo/CMakeLists.txt
@@ -58,13 +58,19 @@ add_library(qpg6100-driver INTERFACE)
 
 if (OT_MTD)
     target_link_libraries(qpg6100-driver
-        INTERFACE
+        INTERFACE 
+            -Wl,--start-group
             ${CMAKE_CURRENT_SOURCE_DIR}/repo/qpg6100/lib/libQorvoQPG6100_mtd.a
+            ${CMAKE_CURRENT_SOURCE_DIR}/repo/qpg6100/lib/libmbedtls_alt.a
+            -Wl,--end-group
     )
 else()
     target_link_libraries(qpg6100-driver
         INTERFACE
+            -Wl,--start-group
             ${CMAKE_CURRENT_SOURCE_DIR}/repo/qpg6100/lib/libQorvoQPG6100_ftd.a
+            ${CMAKE_CURRENT_SOURCE_DIR}/repo/qpg6100/lib/libmbedtls_alt.a
+            -Wl,--end-group
     )
 endif()
 


### PR DESCRIPTION
* Issue
Flag to toggle use of HW engine is not set during CMake builds.
HW acceleration library is not linked in during CMake builds.

* Solution
Removing flag completely to always the HW crypto engine for mbedTLS
Adding library to CMake build