### PR TITLE
[ci] fix Zizmor security findings in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.repository == 'openthread/ot-qorvo' && github.run_id) || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
 
   pretty:
@@ -48,6 +51,7 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         submodules: recursive
+        persist-credentials: false
     - name: Bootstrap
       run: |
         sudo apt-get update
@@ -83,6 +87,7 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         submodules: recursive
+        persist-credentials: false
     - name: Bootstrap
       run: |
         cd /tmp
@@ -109,6 +114,7 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         submodules: recursive
+        persist-credentials: false
     - name: Bootstrap
       run: |
         cd /tmp


### PR DESCRIPTION
Add explicit top-level read-only permissions and set persist-credentials to false for actions/checkout in build.yml.

Modifying workflow YAML files triggers the Zizmor static security scanner in CI. Zizmor flagged excessive-permissions due to missing top-level permissions, causing the mandatory security check evaluation to fail.

- Set permissions.contents to read to scope permissions.
- Set persist-credentials to false under checkout steps.